### PR TITLE
Remove io dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,13 @@ providing the data further down the chain.
 ### IODev
 
 The `IODev` class has been deprecated, and is now an alias to Martin Nowak's
-[std.io](https://github.com/MartinNowak/io) library. At the moment, iopipe has
-io as a dependency, but it may remove that dependency once the deprecation is
-gone.
+[std.io](https://github.com/MartinNowak/io) library. The dependency on std.io
+is optional, and if not included, the `IODev` and related functions are only
+present if your project depends on std.io.
 
-Instead of using `openDev` or `IODev`, it is preferred to use std.io to open
-streams and then build iopipes on top of those.
+However, even when depending on std.io, instead of using `openDev` or `IODev`,
+it is preferred to use std.io to open streams and then build iopipes on top of
+those.
 
 Note a few things:
 
@@ -153,11 +154,9 @@ Note a few things:
    support for earlier compilers, use 0.0.4 of iopipe or earlier. If you use
    0.1.0 or later of iopipe and an earlier compiler, it will not link if you
    use `IODev`.
-2. Because std.io is cross platform, iopipe is now completely cross platform,
-   including Windows support.
-3. A feature of `IODev` that is not in std.io is the ability to use a `FILE *`
+2. A feature of `IODev` that is not in std.io is the ability to use a `FILE *`
    or file descriptor and not close it when the class is destroyed.
-4. std.io more sensibly uses non-copyable structs instead of classes for
+3. std.io more sensibly uses non-copyable structs instead of classes for
    lifetime management. Because iopipe generally copies things around even
    though it's only going to use one copy eventually, you may need to wrap the
    IOs in ref counting or a class (both are supported by std.io).

--- a/dub.sdl
+++ b/dub.sdl
@@ -3,34 +3,39 @@ description "A modular io library in D."
 copyright "Copyright © 2011-2018, Steven Schveighoffer"
 authors "Steven Schveighoffer" "Dmitry Olshansky"
 license "BSL-1.0"
-dependency "io" version="~>0.2.1"
+dependency "io" version="~>0.2.4" optional=true
 subPackage {
    name "byline"
    targetType "executable"
    sourcePaths "examples/byline"
    dependency "iopipe" version="*"
+   dependency "io" version="~>0.2.4"
 }
 subPackage {
    name "convert"
    targetType "executable"
    sourcePaths "examples/convert"
    dependency "iopipe" version="*"
+   dependency "io" version="~>0.2.4"
 }
 subPackage {
    name "unzip"
    targetType "executable"
    sourcePaths "examples/unzip"
    dependency "iopipe" version="*"
+   dependency "io" version="~>0.2.4"
 }
 subPackage {
    name "zip"
    targetType "executable"
    sourcePaths "examples/zip"
    dependency "iopipe" version="*"
+   dependency "io" version="~>0.2.4"
 }
 subPackage {
    name "search"
    targetType "executable"
    sourcePaths "examples/search"
    dependency "iopipe" version="*"
+   dependency "io" version="~>0.2.4"
 }

--- a/examples/byline/byline.d
+++ b/examples/byline/byline.d
@@ -1,6 +1,5 @@
 import iopipe.textpipe;
 import iopipe.bufpipe;
-import iopipe.stream;
 import iopipe.buffer;
 import std.stdio;
 
@@ -23,8 +22,10 @@ void processLines(UTFType utfType, Dev)(Dev dev)
 
 void main(string[] args)
 {
+    import std.io;
+    import std.typecons : refCounted;
     if(args.length > 1 && args[1] == "-nooutput")
         doOutput = false;
-    openDev(0).bufd.runWithEncoding!processLines;
+    File(0).refCounted.bufd.runWithEncoding!processLines;
     stdout.flush();
 }

--- a/examples/convert/convert.d
+++ b/examples/convert/convert.d
@@ -1,8 +1,19 @@
 import iopipe.textpipe;
 import iopipe.bufpipe;
-import iopipe.stream;
 import iopipe.buffer;
+import std.io;
 import std.range.primitives;
+import std.typecons : refCounted;
+
+auto stdin()
+{
+    return File(0).refCounted;
+}
+
+auto stdout()
+{
+    return File(1).refCounted;
+}
 
 void doConvert(UTFType oEnc, Input)(Input input)
 {
@@ -22,7 +33,7 @@ void doConvert(UTFType oEnc, Input)(Input input)
     foreach(w; input.ensureDecodeable.asInputRange)
         put(oChain, w);*/
 
-    input.convertText!(CodeUnit!oEnc, true).encodeText!(oEnc).outputPipe(openDev(1)).process();
+    input.convertText!(CodeUnit!oEnc, true).encodeText!(oEnc).outputPipe(stdout).process();
 }
 
 void translate(UTFType iEnc, Input)(Input input, string outputEncoding)
@@ -32,7 +43,7 @@ void translate(UTFType iEnc, Input)(Input input, string outputEncoding)
     if(oEnc == iEnc)
     {
         // straight pass-through
-        input.outputPipe(openDev(1)).process();
+        input.outputPipe(stdout).process();
     }
     else
     {
@@ -47,7 +58,7 @@ void translate(UTFType iEnc, Input)(Input input, string outputEncoding)
             static if(iEnc == UTFType.UTF16BE)
             {
                 // just changing byte order. Just do a byte swapper.
-                input.arrayCastPipe!(ushort).byteSwapper.arrayCastPipe!(ubyte).outputPipe(openDev(1)).process();
+                input.arrayCastPipe!(ushort).byteSwapper.arrayCastPipe!(ubyte).outputPipe(stdout).process();
             }
             else
             {
@@ -60,7 +71,7 @@ void translate(UTFType iEnc, Input)(Input input, string outputEncoding)
             static if(iEnc == UTFType.UTF16LE)
             {
                 // just changing byte order. Just do a byte swapper.
-                input.arrayCastPipe!(ushort).byteSwapper.arrayCastPipe!(ubyte).outputPipe(openDev(1)).process();
+                input.arrayCastPipe!(ushort).byteSwapper.arrayCastPipe!(ubyte).outputPipe(stdout).process();
             }
             else
             {
@@ -73,7 +84,7 @@ void translate(UTFType iEnc, Input)(Input input, string outputEncoding)
             static if(iEnc == UTFType.UTF32BE)
             {
                 // just changing byte order. Just do a byte swapper.
-                input.arrayCastPipe!(uint).byteSwapper.arrayCastPipe!(ubyte).outputPipe(openDev(1)).process();
+                input.arrayCastPipe!(uint).byteSwapper.arrayCastPipe!(ubyte).outputPipe(stdout).process();
             }
             else
             {
@@ -86,7 +97,7 @@ void translate(UTFType iEnc, Input)(Input input, string outputEncoding)
             static if(iEnc == UTFType.UTF32LE)
             {
                 // just changing byte order. Just do a byte swapper.
-                input.arrayCastPipe!(uint).byteSwapper.arrayCastPipe!(ubyte).outputPipe(openDev(1)).process();
+                input.arrayCastPipe!(uint).byteSwapper.arrayCastPipe!(ubyte).outputPipe(stdout).process();
             }
             else
             {
@@ -103,5 +114,5 @@ void translate(UTFType iEnc, Input)(Input input, string outputEncoding)
 void main(string[] args)
 {
     // convert all data from input stream to given format
-    runWithEncoding!(translate)(openDev(0).bufd, args[1]);
+    runWithEncoding!(translate)(stdin.bufd, args[1]);
 }

--- a/examples/unzip/unzip.d
+++ b/examples/unzip/unzip.d
@@ -1,11 +1,12 @@
 import iopipe.zip;
-import iopipe.stream;
 import iopipe.bufpipe;
+import std.io;
+import std.typecons : refCounted;
 
 void main()
 {
     // decompress the input into the output
-    auto nbytes = openDev(0).bufd.unzip.outputPipe(openDev(1)).process();
-    import std.stdio;
+    auto nbytes = File(0).refCounted.bufd.unzip.outputPipe(File(1).refCounted).process();
+    import std.stdio : stderr;
     stderr.writefln("decompressed %s bytes", nbytes);
 }

--- a/examples/zip/zip.d
+++ b/examples/zip/zip.d
@@ -1,11 +1,12 @@
 import iopipe.zip;
-import iopipe.stream;
 import iopipe.bufpipe;
+import std.io;
+import std.typecons : refCounted;
 
 void main()
 {
     // decompress the input into the output
-    auto nbytes = bufd(openDev(0)).zip(CompressionFormat.gzip).outputPipe(openDev(1)).process();
-    import std.stdio;
+    auto nbytes = bufd(File(0).refCounted).zip(CompressionFormat.gzip).outputPipe(File(1).refCounted).process();
+    import std.stdio : stderr;
     stderr.writefln("compressed %s bytes", nbytes);
 }

--- a/source/iopipe/stream.d
+++ b/source/iopipe/stream.d
@@ -6,37 +6,41 @@ at http://www.boost.org/LICENSE_1_0.txt)
 Authors:   Steven Schveighoffer
  */
 module iopipe.stream;
-import std.io;
 
-version(Posix)
+version(Have_io)
 {
-    /// Deprecated: use std.io directly
-    deprecated alias IODev = IOObject!(File);
+    import std.io;
 
-    /**
-     * Construct an input stream based on the file descriptor
-     *
-     * params:
-     * fd = The file descriptor to wrap
-     *
-     * Deprecated: Use https://code.dlang.org/io for low-level device i/o
-     */
-    deprecated("use std.io")
-        auto openDev(int fd)
-        {
-            return ioObject(File(fd));
-        }
+    version(Posix)
+    {
+        /// Deprecated: use std.io directly
+        deprecated alias IODev = IOObject!(File);
 
-    /**
-     * Open a file by name.
-     *
-     * Deprecated: Use https://code.dlang.org/io for low-level device i/o
-     */
-    deprecated("use std.io")
-        auto openDev(in char[] name, Mode mode = Mode.read | Mode.binary)
-        {
-            return ioObject(File(name, mode));
-        }
+        /**
+         * Construct an input stream based on the file descriptor
+         *
+         * params:
+         * fd = The file descriptor to wrap
+         *
+         * Deprecated: Use https://code.dlang.org/io for low-level device i/o
+         */
+        deprecated("use std.io")
+            auto openDev(int fd)
+            {
+                return ioObject(File(fd));
+            }
+
+        /**
+         * Open a file by name.
+         *
+         * Deprecated: Use https://code.dlang.org/io for low-level device i/o
+         */
+        deprecated("use std.io")
+            auto openDev(in char[] name, Mode mode = Mode.read | Mode.binary)
+            {
+                return ioObject(File(name, mode));
+            }
+    }
 }
 
 


### PR DESCRIPTION
This removes std.io as a required dependency. Should help with the build, and also makes iopipe usable with any other stream-based system without having to include std.io.