### PR TITLE
Small fix: Backwards compatibility with debian ldc

### DIFF
--- a/source/iopipe/stream.d
+++ b/source/iopipe/stream.d
@@ -146,7 +146,7 @@ struct RangeDev(R) {
             return n;
         }
         else
-            static assert(false, "Incompatible read for type `", Buf, "` and source range `", R, "`");
+            static assert(false, "Incompatible read for type `" ~ Buf.stringof ~ "` and source range `" ~ R.stringof ~ "`");
     }
 }
 


### PR DESCRIPTION
LDC - the LLVM D compiler (1.30.0):   based on DMD v2.100.1 and LLVM 14.0.6